### PR TITLE
Create whole directory path for initial properties

### DIFF
--- a/src/main/java/versioneye/SuperMojo.java
+++ b/src/main/java/versioneye/SuperMojo.java
@@ -129,10 +129,9 @@ public class SuperMojo extends AbstractMojo {
     }
 
     private void createPropertiesFile(File file) throws IOException {
-        String resoucesPath = projectDirectory + "/src/main/resources/";
-        File resource = new File(resoucesPath);
-        if (!resource.exists()){
-            resource.mkdir();
+        File parent = file.getParentFile();
+        if (!parent.exists()){
+            parent.mkdirs();
         }
         file.createNewFile();
     }


### PR DESCRIPTION
If the src/main/resources directory is missing it tries to create it, but this depends on the parent existing. With this changes the whole chain of directories will be created and the hardcoded path name duplication is avoided.
