### PR TITLE
Ignore eclipse specific directories and dotfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ capybara-*.html
 versioneye-maven-plugin.iml
 versioneye-maven-plugin.ipr
 versioneye-maven-plugin.iws
+.classpath
+.project
+.settings


### PR DESCRIPTION
gitignore some typical eclipse resources to avoid the project getting dirty when it is build. Alternative would be to check in (some of) the files. Would you prefer that?
