### PR TITLE
Fix for #25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
       <plugin>
         <groupId>com.versioneye</groupId>
         <artifactId>versioneye-maven-plugin</artifactId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.0.1</version>
         <configuration>
             <!-- <baseUrl>https://www.versioneye.com</baseUrl> -->
             <!--<baseUrl>http://127.0.0.1:3000</baseUrl>-->


### PR DESCRIPTION
Reset the used plugin version to "2.0.1" (cf. https://github.com/versioneye/versioneye_maven_plugin/issues/25)
