### PR TITLE
Included licenses tag from pom.xml to the generated pom.json file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>com.versioneye</groupId>
   <artifactId>versioneye-maven-plugin</artifactId>
-  <version>3.11.0</version>
+  <version>3.11.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>versioneye-maven-plugin</name>

--- a/src/main/java/com/versioneye/utils/JsonUtils.java
+++ b/src/main/java/com/versioneye/utils/JsonUtils.java
@@ -119,6 +119,7 @@ public class JsonUtils {
         pom.put("version", project.getVersion());
         pom.put("language", "Java");
         pom.put("prod_type", "Maven2");
+        pom.put("licenses", project.getLicenses());
         pom.put("dependencies", dependencyHashes);
         return pom;
     }


### PR DESCRIPTION
The licenses tag is read from the pom.xml and included into the pom.json files to enable versioneye server to show license information for maven projects without querying the maven central for that.

Some examples of generated json files are provided below:

```json
{
    "prod_type":"Maven2",
    "licenses":[{"name":"GPLv3","url":"http://www.gnu.org/licenses/lgpl-3.0.txt","distribution":null,"comments":null}],
    "group_id":"org.cloudsimplus", "artifact_id":"cloudsim-plus", 
    "version":"1.0", "name":"CloudSim Plus API", "language":"Java",
    "dependencies":[]
}
```

```json
{
    "prod_type":"Maven2", 
    "licenses":[{"name":"GPLv3","url":"http://www.gnu.org/licenses/lgpl-3.0.txt","distribution":null,"comments":null}],
    "group_id":"org.cloudsimplus", "language":"Java", "artifact_id":"cloudsim-plus-examples", 
    "version":"1.0", "name":"CloudSim Plus Examples",
    "dependencies":[]
}
```